### PR TITLE
Restore language switching and translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,6 +278,341 @@
   let deleteAuthCache=null; // { dept, ts }
   const DELETE_AUTH_CACHE_MS=10*60*1000; // 10 分钟内复用验证
 
+  /***** —— 语言与国际化 —— *****/
+  const translations={
+    zh:{
+      pageTitle:"学生上课外出申请（公假外出）",
+      appTitle:"学生上课外出申请（公假外出）",
+      tabApply:"申请",
+      tabRecords:"记录 / 查看",
+      tabMonitor:"监看",
+      languageLabel:"界面语言：",
+      languageOptionZh:"简体中文",
+      languageOptionEn:"English",
+      labelIdQuick:"学号直达：",
+      btnAddById:"加入名单",
+      labelNameSearch:"姓名模糊搜：",
+      labelIdsBulk:"批量学号：",
+      btnAddBulk:"批量加入名单",
+      btnClearList:"清空名单",
+      labelCurrentList:"本次名单：",
+      labelDateSelect:"日期选择：",
+      hintAutoAddDate:"选择后自动加入",
+      labelStartDate:"起：",
+      labelEndDate:"止：",
+      btnAddDateRange:"加入范围",
+      btnAddSelectedDate:"加入所选",
+      labelPeriod:"时间段：",
+      labelActivity:"活动名称：",
+      btnGenerateText:"生成中英文本",
+      btnSaveToRecords:"保存到记录",
+      labelCnNotice:"中文通知：",
+      labelEnNotice:"English Letter:",
+      btnCopyCn:"复制中文TXT",
+      btnCopyEn:"复制英文TXT",
+      labelSubmitPassword:"提交前简单密码",
+      labelPassword:"密码：",
+      labelFilterDates:"按日期筛选：",
+      btnExportCsv:"导出筛选CSV",
+      btnDeleteSelected:"删除所选记录",
+      labelFilterClass:"按班级筛选：",
+      labelFilterQuery:"快速搜索：",
+      thDate:"日期",
+      thPeriod:"时间段",
+      thStudentId:"学号",
+      thClass:"班级",
+      thNameCn:"中文姓名",
+      thNameEn:"英文姓名",
+      thActivity:"活动",
+      thDepartment:"部门",
+      thActions:"操作",
+      labelMonitorDates:"日期选择：",
+      hintAutoAddMonDate:"选择后自动加入",
+      labelMonitorTeacher:"老师筛选：",
+      labelMonitorClass:"班级筛选：",
+      labelMonitorMode:"显示模式：",
+      optionMonitorTimetable:"时间表",
+      optionMonitorTable:"表格",
+      optionMonitorCards:"卡片",
+      btnMonitorRefresh:"刷新",
+      btnMonitorExport:"导出当前视图CSV",
+      monitorHint:"说明：① 多日期可同时监看；② 初中（J…）英/马/数分组课严格按 h/i/f 精确匹配；③ 未提供课表将仅显示记录。",
+      phIdQuick:"输入学号后回车或点加入",
+      phNameSearch:"中文/英文/拼音…",
+      phIdsBulk:"支持逗号、空格、换行分隔",
+      phPeriod:"如：第3-4节 或 10:00-11:30",
+      phActivity:"如：全州排球赛",
+      phFilterDates:"支持多日期：2025-09-25, 2025-09-26",
+      phFilterClass:"如：J1Z（留空=全部）",
+      phFilterQuery:"学号/中文/英文 关键词",
+      optionAllTeachers:"（全部老师）",
+      optionAllClasses:"（全部班级）",
+      errorLoadCoreData:"加载学生/课表数据失败，请稍后再试。",
+      studentIdLabel:"学号 {id}",
+      unnamedStudent:"未命名学生",
+      reasonFallback:"未提供理由",
+      monitorReasonTitle:"外出学生",
+      monitorDepartmentPrefix:"部门：",
+      reasonLabel:"事由：",
+      btnClose:"关闭",
+      promptDeletionPassword:"请输入{action}密码（同提交密码）：",
+      errorPasswordIncorrect:"密码不正确",
+      errorEnterStudentId:"请先输入学号。",
+      errorStudentNotFound:"未找到该学号的学生。",
+      errorEnterIdsFirst:"请先填写学号。",
+      bulkAddSummaryWithMissing:"成功加入 {count} 人，以下学号未匹配：{missing}",
+      bulkAddSummary:"成功加入 {count} 人。",
+      errorSelectRange:"请先选择起止日期。",
+      errorRangeOrder:"开始日期不能晚于结束日期。",
+      conflictWeekend:"所选日期为周末，无课表。",
+      conflictNoPeriods:"无法识别时间段，请检查格式。",
+      errorNeedList:"请先加入至少一名学生。",
+      errorNeedDate:"请先加入至少一个日期。",
+      errorNeedPeriod:"请输入时间段。",
+      errorNeedActivity:"请输入活动名称。",
+      saveSuccess:"已保存 {count} 条记录。",
+      saveNothing:"没有可保存的记录。",
+      saveFailed:"保存失败，请稍后再试。",
+      copyCnSuccess:"已复制中文文本。",
+      copyEnSuccess:"已复制英文文本。",
+      copyFailed:"复制失败：{message}",
+      copyEnFailed:"复制英文文本失败：{message}",
+      errorFetchRecords:"加载记录失败，请稍后再试。",
+      deleteRecords:"删除记录",
+      errorMissingDeleteKeys:"缺少定位字段，无法删除。",
+      confirmDeleteSingle:"确认删除 {date} {studentId} 这条记录？",
+      errorDeleteFailed:"删除失败，请稍后再试。",
+      errorDeletePartial:"删除过程中出现错误，部分记录可能未被删除。",
+      alertSelectRecords:"请先选择需要删除的记录。",
+      confirmDeleteSelected:"确定删除选中的 {count} 条记录？此操作不可恢复。",
+      successDelete:"已删除所选记录。",
+      exportEmpty:"无可导出的内容。",
+      errorMonitorRange:"请先选择监看起止日期。",
+      errorMonitorNeedDate:"请先加入至少一个监看日期。",
+      errorMonitorFetch:"加载监看数据失败。"
+    },
+    en:{
+      pageTitle:"Student Official Leave Application",
+      appTitle:"Student Official Leave Application",
+      tabApply:"Apply",
+      tabRecords:"Records / Review",
+      tabMonitor:"Monitor",
+      languageLabel:"Interface language:",
+      languageOptionZh:"Simplified Chinese",
+      languageOptionEn:"English",
+      labelIdQuick:"Student ID quick add:",
+      btnAddById:"Add to list",
+      labelNameSearch:"Name search:",
+      labelIdsBulk:"Student IDs (bulk):",
+      btnAddBulk:"Add all to list",
+      btnClearList:"Clear list",
+      labelCurrentList:"Current list:",
+      labelDateSelect:"Pick dates:",
+      hintAutoAddDate:"Auto-add after selecting",
+      labelStartDate:"Start:",
+      labelEndDate:"End:",
+      btnAddDateRange:"Add range",
+      btnAddSelectedDate:"Add selected",
+      labelPeriod:"Time slot:",
+      labelActivity:"Activity name:",
+      btnGenerateText:"Generate CN/EN text",
+      btnSaveToRecords:"Save to records",
+      labelCnNotice:"Chinese notice:",
+      labelEnNotice:"English letter:",
+      btnCopyCn:"Copy Chinese TXT",
+      btnCopyEn:"Copy English TXT",
+      labelSubmitPassword:"Submit password",
+      labelPassword:"Password:",
+      labelFilterDates:"Filter by dates:",
+      btnExportCsv:"Export filtered CSV",
+      btnDeleteSelected:"Delete selected records",
+      labelFilterClass:"Filter by class:",
+      labelFilterQuery:"Quick search:",
+      thDate:"Date",
+      thPeriod:"Period",
+      thStudentId:"Student ID",
+      thClass:"Class",
+      thNameCn:"Name (CN)",
+      thNameEn:"Name (EN)",
+      thActivity:"Activity",
+      thDepartment:"Department",
+      thActions:"Actions",
+      labelMonitorDates:"Pick dates:",
+      hintAutoAddMonDate:"Auto-add after selecting",
+      labelMonitorTeacher:"Filter by teacher:",
+      labelMonitorClass:"Filter by class:",
+      labelMonitorMode:"Display mode:",
+      optionMonitorTimetable:"Timetable",
+      optionMonitorTable:"Table",
+      optionMonitorCards:"Cards",
+      btnMonitorRefresh:"Refresh",
+      btnMonitorExport:"Export current view CSV",
+      monitorHint:"Notes: (1) Multiple dates can be monitored at once. (2) For junior (J...) English/BM/Math split classes, match the h/i/f groups exactly. (3) When no timetable is available, only records are shown.",
+      phIdQuick:"Enter student ID then press Enter or Add",
+      phNameSearch:"Chinese/English/Pinyin…",
+      phIdsBulk:"Comma, space or newline separated IDs",
+      phPeriod:"e.g. Period 3-4 or 10:00-11:30",
+      phActivity:"e.g. State volleyball meet",
+      phFilterDates:"Multiple dates allowed: 2025-09-25, 2025-09-26",
+      phFilterClass:"e.g. J1Z (leave empty = all)",
+      phFilterQuery:"Student ID / CN / EN keywords",
+      optionAllTeachers:"All teachers",
+      optionAllClasses:"All classes",
+      errorLoadCoreData:"Failed to load students/timetable. Please try again later.",
+      studentIdLabel:"ID {id}",
+      unnamedStudent:"Unnamed student",
+      reasonFallback:"No reason provided",
+      monitorReasonTitle:"Student",
+      monitorDepartmentPrefix:"Department: ",
+      reasonLabel:"Reason:",
+      btnClose:"Close",
+      promptDeletionPassword:"Enter password for {action} (same as submit password):",
+      errorPasswordIncorrect:"Incorrect password",
+      errorEnterStudentId:"Please enter a student ID first.",
+      errorStudentNotFound:"No student found with that ID.",
+      errorEnterIdsFirst:"Please enter the student IDs first.",
+      bulkAddSummaryWithMissing:"Added {count} students. These IDs were not found: {missing}",
+      bulkAddSummary:"Added {count} students.",
+      errorSelectRange:"Please select start and end dates first.",
+      errorRangeOrder:"Start date cannot be after end date.",
+      conflictWeekend:"Selected date falls on a weekend; no timetable available.",
+      conflictNoPeriods:"Could not parse the time slot. Check the format.",
+      errorNeedList:"Add at least one student first.",
+      errorNeedDate:"Add at least one date first.",
+      errorNeedPeriod:"Enter a time slot.",
+      errorNeedActivity:"Enter the activity name.",
+      saveSuccess:"Saved {count} records.",
+      saveNothing:"Nothing to save.",
+      saveFailed:"Failed to save. Please try again.",
+      copyCnSuccess:"Chinese text copied.",
+      copyEnSuccess:"English text copied.",
+      copyFailed:"Copy failed: {message}",
+      copyEnFailed:"Failed to copy English text: {message}",
+      errorFetchRecords:"Failed to load records. Please try again.",
+      deleteRecords:"Delete record",
+      errorMissingDeleteKeys:"Missing required keys for deletion.",
+      confirmDeleteSingle:"Delete the record for {date} {studentId}?",
+      errorDeleteFailed:"Failed to delete. Please try again.",
+      errorDeletePartial:"An error occurred during deletion; some records may remain.",
+      alertSelectRecords:"Select records to delete first.",
+      confirmDeleteSelected:"Delete the {count} selected records? This action cannot be undone.",
+      successDelete:"Selected records deleted.",
+      exportEmpty:"Nothing to export.",
+      errorMonitorRange:"Select start and end dates for monitoring first.",
+      errorMonitorNeedDate:"Add at least one monitoring date first.",
+      errorMonitorFetch:"Failed to load monitor data."
+    }
+  };
+  const LANGUAGE_STORAGE_KEY='leave_app_lang';
+  const DEFAULT_LANGUAGE='zh';
+  const FALLBACK_LANGUAGE='zh';
+  const languageChangeCallbacks=new Set();
+
+  function safeStorageGet(key){
+    try{ return localStorage.getItem(key); }
+    catch(err){ return null; }
+  }
+  function safeStorageSet(key,value){
+    try{ localStorage.setItem(key,value); }
+    catch(err){ /* ignore */ }
+  }
+
+  function normalizeLanguageTag(tag){
+    if(!tag) return '';
+    const lower=String(tag).toLowerCase();
+    if(lower.startsWith('zh')) return 'zh';
+    if(lower.startsWith('en')) return 'en';
+    return '';
+  }
+
+  function detectInitialLanguage(){
+    const stored=normalizeLanguageTag(safeStorageGet(LANGUAGE_STORAGE_KEY));
+    if(stored && translations[stored]) return stored;
+    const docLang=normalizeLanguageTag(document?.documentElement?.lang);
+    if(docLang && translations[docLang]) return docLang;
+    const navLang=normalizeLanguageTag((navigator.languages && navigator.languages[0]) || navigator.language);
+    if(navLang && translations[navLang]) return navLang;
+    return DEFAULT_LANGUAGE;
+  }
+
+  function formatTranslation(template,params){
+    if(!params) return template;
+    return template.replace(/\{(\w+)\}/g,(match,key)=>{
+      if(Object.prototype.hasOwnProperty.call(params,key)){
+        const val=params[key];
+        return val==null?'' : String(val);
+      }
+      return match;
+    });
+  }
+
+  let currentLanguage=detectInitialLanguage();
+
+  function t(key,params){
+    const dict=translations[currentLanguage] || {};
+    let template=dict[key];
+    if(template==null){
+      template=translations[FALLBACK_LANGUAGE]?.[key];
+    }
+    if(template==null){
+      return key;
+    }
+    if(params && typeof params==='object'){
+      return formatTranslation(template,params);
+    }
+    return template;
+  }
+
+  function applyTranslationsToDom(){
+    if(typeof document==='undefined') return;
+    document.querySelectorAll('[data-i18n-text]').forEach(el=>{
+      const key=el.getAttribute('data-i18n-text');
+      if(!key) return;
+      el.textContent=t(key);
+    });
+    document.querySelectorAll('[data-i18n-placeholder]').forEach(el=>{
+      const key=el.getAttribute('data-i18n-placeholder');
+      if(!key) return;
+      const translated=t(key);
+      el.setAttribute('placeholder',translated);
+    });
+    const selectEl=document.getElementById('languageSelect');
+    if(selectEl && selectEl.value!==currentLanguage){
+      selectEl.value=currentLanguage;
+    }
+    document.title=t('pageTitle');
+  }
+
+  function setLanguage(lang,options={}){
+    const { persist=true } = options;
+    let normalized=normalizeLanguageTag(lang);
+    if(!translations[normalized]) normalized=DEFAULT_LANGUAGE;
+    const previous=currentLanguage;
+    currentLanguage=normalized;
+    if(persist){
+      safeStorageSet(LANGUAGE_STORAGE_KEY,currentLanguage);
+    }
+    if(document?.documentElement){
+      document.documentElement.lang=currentLanguage==='zh'?'zh-CN':'en';
+    }
+    applyTranslationsToDom();
+    languageChangeCallbacks.forEach(cb=>{
+      try{ cb(currentLanguage,previous); }
+      catch(err){ console.error('Language change callback failed:',err); }
+    });
+    return currentLanguage;
+  }
+
+  function onLanguageChange(callback){
+    if(typeof callback==='function'){
+      languageChangeCallbacks.add(callback);
+    }
+  }
+
+  function getCurrentLanguage(){
+    return currentLanguage;
+  }
+
   /***** —— 3) 从 Supabase 读取学生 + 课表 —— *****/
   function buildTeacherClassSelects(){
   // 依赖：schedule、monTeacher、monClass 已经声明
@@ -350,6 +685,7 @@
   // === 复制你的业务代码到这里 ===
 
 /***** —— DOM 绑定 —— *****/
+const languageSelect=document.getElementById('languageSelect');
 const idQuick=document.getElementById('idQuick');
 const btnAddById=document.getElementById('btnAddById');
 const idsBulk=document.getElementById('idsBulk');
@@ -557,39 +893,29 @@ function parseDepartmentFromPassword(input){
 
 function ensureDeletionAuthorized(actionKey='deleteRecords'){
   const actionLabel = typeof actionKey==='string' ? t(actionKey) : actionKey;
-function ensureDeletionAuthorized(actionLabel='删除记录'){
-  const now=Date.now();
-  if(deleteAuthCache && (now-deleteAuthCache.ts)<DELETE_AUTH_CACHE_MS){
+  const now = Date.now();
+  if(deleteAuthCache && (now - deleteAuthCache.ts) < DELETE_AUTH_CACHE_MS){
     return deleteAuthCache.dept;
   }
 
   if(pwdInp && pwdInp.value){
-    const dept=parseDepartmentFromPassword(pwdInp.value);
+    const dept = parseDepartmentFromPassword(pwdInp.value);
     if(dept){
-      deleteAuthCache={ dept, ts:now };
+      deleteAuthCache = { dept, ts: now };
       return dept;
     }
   }
 
   while(true){
-    const input=prompt(t('promptDeletionPassword',{ action: actionLabel }), '');
+    const input = prompt(t('promptDeletionPassword',{ action: actionLabel }), '');
     if(input===null) return null;
-    const dept=parseDepartmentFromPassword(input);
+    const dept = parseDepartmentFromPassword(input);
     if(dept){
-      deleteAuthCache={ dept, ts:Date.now() };
+      deleteAuthCache = { dept, ts: Date.now() };
       return dept;
     }
     alert(t('errorPasswordIncorrect'));
   }
-  const input=prompt(`请输入${actionLabel}密码（同提交密码）：`,'');
-  if(input===null) return null;
-  const dept=parseDepartmentFromPassword(input);
-  if(!dept){
-    alert('密码不正确');
-    return null;
-  }
-  deleteAuthCache={ dept, ts:now };
-  return dept;
 }
 
 function pickStudentGroupKey(subject){
@@ -1037,9 +1363,6 @@ tblBody.addEventListener('click', async e=>{
   if(!date || !sid || !ts){ alert(t('errorMissingDeleteKeys')); return; }
   if(!confirm(t('confirmDeleteSingle',{ date, studentId:sid }))) return;
   if(!ensureDeletionAuthorized('deleteRecords')) return;
-  if(!date || !sid || !ts){ alert('缺少定位字段，无法删除。'); return; }
-  if(!confirm(`确认删除：${date} ${sid} 这条记录？`)) return;
-  if(!ensureDeletionAuthorized('删除记录')) return;
 
   const { error } = await supabase
     .from('applications_flat')
@@ -1066,9 +1389,6 @@ btnDeleteSelected.onclick=async ()=>{
   if(!selected.length){ alert(t('alertSelectRecords')); return; }
   if(!confirm(t('confirmDeleteSelected',{ count:selected.length }))) return;
   if(!ensureDeletionAuthorized('deleteRecords')) return;
-  if(!selected.length){ alert('请先选择需要删除的记录'); return; }
-  if(!confirm(`确定删除选中的 ${selected.length} 条记录？此操作不可恢复。`)) return;
-  if(!ensureDeletionAuthorized('删除记录')) return;
 
   for(const cb of selected){
     const date=cb.getAttribute('data-date');
@@ -1086,14 +1406,12 @@ btnDeleteSelected.onclick=async ()=>{
     if(error){
       console.error('删除失败：', error);
       alert(t('errorDeletePartial'));
-      alert('删除过程中出现错误，部分记录可能未被删除。');
       refreshTable();
       return;
     }
   }
 
   alert(t('successDelete'));
-  alert('已删除所选记录。');
   refreshTable();
 };
 
@@ -1488,6 +1806,23 @@ async function setActiveTab(which){
 tabApply.onclick=()=>setActiveTab('apply');
 tabRecords.onclick=()=>setActiveTab('records');
 tabMonitor.onclick=()=>setActiveTab('monitor');
+
+onLanguageChange(()=>{
+  try{ buildTeacherClassSelects(); }catch(err){ console.warn('Failed to rebuild teacher/class lists after language change.',err); }
+  try{ updateConflict(); }catch(err){ console.warn('Failed to update conflict notice after language change.',err); }
+  document.querySelectorAll('#tblBody button[data-idx]').forEach(btn=>{ btn.textContent=t('deleteRecords'); });
+  if(pageMonitor && pageMonitor.style.display!=='none'){
+    buildMonitorView();
+  }
+});
+
+if(languageSelect){
+  languageSelect.addEventListener('change',event=>{
+    setLanguage(event.target.value);
+  });
+}
+
+setLanguage(getCurrentLanguage(),{ persist:false });
 
 // Supabase 核心数据在模块顶部通过 DOMContentLoaded 注册加载
 </script>


### PR DESCRIPTION
## Summary
- add a shared translation catalog and helpers so all interface text/alerts support both Chinese and English
- hook the language selector into the new translator and refresh dynamic views when the language changes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e10399d1d48330b3b3f6d042c315b5