### PR TITLE
Gracefully handle Supabase timeouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
   .lang-switch{display:flex;align-items:center;gap:8px;color:#52616b;font-size:14px}
   .lang-switch select{min-width:140px;padding:6px 10px;border-radius:999px;border:1px solid #cfd8e3;background:#fff;font-size:14px}
   .app-main{display:flex;flex-direction:column;gap:18px}
+  .tab-page{display:block}
+  body.js-tabs-ready .tab-page{display:none}
+  body.js-tabs-ready .tab-page.is-active{display:block}
   .card{border:1px solid #e0e7ff;border-radius:16px;padding:18px;margin-bottom:0;background:#fff;box-shadow:0 18px 36px -24px rgba(15,23,42,.32)}
   .card + .card{margin-top:16px}
   label{display:inline-block;min-width:88px}
@@ -99,7 +102,7 @@
 
   <main class="app-main">
   <!-- 申请页 -->
-  <section id="page-apply" style="display:none;" aria-labelledby="tab-apply" role="tabpanel">
+  <section id="page-apply" class="tab-page" aria-labelledby="tab-apply" role="tabpanel">
   <div class="card">
     <div class="row">
       <div class="grow">
@@ -182,7 +185,7 @@
   </section>
 
   <!-- 记录/查看页 -->
-  <section id="page-records" style="display:none;" aria-labelledby="tab-records" role="tabpanel">
+  <section id="page-records" class="tab-page" aria-labelledby="tab-records" role="tabpanel">
   <div class="card">
     <div class="row">
       <div class="grow">
@@ -225,7 +228,7 @@
   </section>
 
   <!-- 监看页 -->
-  <section id="page-monitor" aria-labelledby="tab-monitor" role="tabpanel">
+  <section id="page-monitor" class="tab-page" aria-labelledby="tab-monitor" role="tabpanel">
   <div class="card">
     <div class="row">
       <div class="grow">
@@ -278,6 +281,31 @@
   const SUPABASE_URL = "https://ktgrbbzpqfuiprpkbtbk.supabase.co";
   const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt0Z3JiYnpwcWZ1aXBycGtidGJrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTkzMjkzMTQsImV4cCI6MjA3NDkwNTMxNH0.Ik-rT3rqGRx1PUYBd41ZofQf90H0v8vru67dv7ktNvs";
   const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const SUPABASE_TIMEOUT_MS = 10000;
+
+  function withTimeout(promise, { ms = SUPABASE_TIMEOUT_MS, message } = {}){
+    return new Promise((resolve, reject)=>{
+      const timer=setTimeout(()=>{
+        const error=new Error(message || 'Request timed out');
+        error.name='TimeoutError';
+        reject(error);
+      }, ms);
+      promise.then(value=>{
+        clearTimeout(timer);
+        resolve(value);
+      },err=>{
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  function isTimeoutError(err){
+    if(!err) return false;
+    if(err.name==='TimeoutError') return true;
+    const msg=(err.message||'').toLowerCase();
+    return msg.includes('timeout') || msg.includes('time out');
+  }
 
   /***** —— 2) 全局变量 —— *****/
   const DEPARTMENT_PASSWORDS=[
@@ -375,6 +403,7 @@
       optionAllTeachers:"（全部老师）",
       optionAllClasses:"（全部班级）",
       errorLoadCoreData:"加载学生/课表数据失败，请稍后再试。",
+      errorSupabaseTimeout:"请求超时，请检查网络后再试。",
       studentIdLabel:"学号 {id}",
       unnamedStudent:"未命名学生",
       reasonFallback:"未提供理由",
@@ -510,6 +539,7 @@
       optionAllTeachers:"All teachers",
       optionAllClasses:"All classes",
       errorLoadCoreData:"Failed to load students/timetable. Please try again later.",
+      errorSupabaseTimeout:"Request timed out. Please check your connection and try again.",
       studentIdLabel:"ID {id}",
       unnamedStudent:"Unnamed student",
       reasonFallback:"No reason provided",
@@ -799,10 +829,12 @@
     try {
       resetLookupCaches();
 
-      const { data: stu, error: e1 } = await supabase
-        .from("students")
-        .select("id,name_cn,name_en,pinyin,class,group_en,group_bm,group_math")
-        .order("id");
+      const { data: stu, error: e1 } = await withTimeout(
+        supabase
+          .from("students")
+          .select("id,name_cn,name_en,pinyin,class,group_en,group_bm,group_math")
+          .order("id")
+      );
       if (e1) throw e1;
       students = (stu || []).map(s => ({
         id: s.id,
@@ -815,45 +847,60 @@
         math: (s.group_math || "").toLowerCase(),
       }));
 
-      const { data: subjectsData, error: subjectsError } = await supabase
-        .from("subjects")
-        .select("id,name_cn,name_en");
-      if (subjectsError) {
-        console.warn("[Supabase] load subjects failed:", subjectsError);
-      } else {
-        (subjectsData || []).forEach(rememberSubjectRecord);
+      const subjectsResp = await withTimeout(
+        supabase
+          .from("subjects")
+          .select("id,name_cn,name_en")
+      ).catch(err=>({ data: null, error: err }));
+      if(subjectsResp){
+        if(subjectsResp.error){
+          console.warn("[Supabase] load subjects failed:", subjectsResp.error);
+        }else{
+          (subjectsResp.data || []).forEach(rememberSubjectRecord);
+        }
       }
 
-      const { data: subjectMapData, error: subjectMapError } = await supabase
-        .from("subject_map")
-        .select("name_cn,name_en");
-      if (subjectMapError) {
-        console.warn("[Supabase] load subject_map failed:", subjectMapError);
-      } else {
-        (subjectMapData || []).forEach(row => {
-          rememberSubjectName(row?.name_cn, row?.name_en);
-        });
+      const subjectMapResp = await withTimeout(
+        supabase
+          .from("subject_map")
+          .select("name_cn,name_en")
+      ).catch(err=>({ data: null, error: err }));
+      if(subjectMapResp){
+        if(subjectMapResp.error){
+          console.warn("[Supabase] load subject_map failed:", subjectMapResp.error);
+        }else{
+          (subjectMapResp.data || []).forEach(row => {
+            rememberSubjectName(row?.name_cn, row?.name_en);
+          });
+        }
       }
 
-      const { data: teachersData, error: teachersError } = await supabase
-        .from("teachers")
-        .select("id,name_cn,name_en");
-      if (teachersError) {
-        console.warn("[Supabase] load teachers failed:", teachersError);
-      } else {
-        (teachersData || []).forEach(rememberTeacherRecord);
+      const teachersResp = await withTimeout(
+        supabase
+          .from("teachers")
+          .select("id,name_cn,name_en")
+      ).catch(err=>({ data: null, error: err }));
+      if(teachersResp){
+        if(teachersResp.error){
+          console.warn("[Supabase] load teachers failed:", teachersResp.error);
+        }else{
+          (teachersResp.data || []).forEach(rememberTeacherRecord);
+        }
       }
 
       const linkMap=new Map();
-      const { data: linksData, error: linksError } = await supabase
-        .from("timetable_links")
-        .select("timetable_id,subject_id,teacher_id,subjects(name_cn,name_en),teachers(name_cn,name_en)");
-      if (linksError) {
-        console.warn("[Supabase] load timetable_links failed:", linksError);
-      } else {
-        (linksData || []).forEach(link => {
-          const subjectCnRaw = link?.subjects?.name_cn;
-          const subjectEnRaw = link?.subjects?.name_en;
+      const linksResp = await withTimeout(
+        supabase
+          .from("timetable_links")
+          .select("timetable_id,subject_id,teacher_id,subjects(name_cn,name_en),teachers(name_cn,name_en)")
+      ).catch(err=>({ data: null, error: err }));
+      if(linksResp){
+        if(linksResp.error){
+          console.warn("[Supabase] load timetable_links failed:", linksResp.error);
+        }else{
+          (linksResp.data || []).forEach(link => {
+            const subjectCnRaw = link?.subjects?.name_cn;
+            const subjectEnRaw = link?.subjects?.name_en;
           const teacherCnRaw = link?.teachers?.name_cn;
           const teacherEnRaw = link?.teachers?.name_en;
           rememberSubjectName(subjectCnRaw, subjectEnRaw);
@@ -871,14 +918,17 @@
             teacher: (teacherCn || teacherEn) ? { cn: teacherCn, en: teacherEn } : null,
           });
         });
+        }
       }
 
-      const { data: tt, error: e2 } = await supabase
-        .from("timetable")
-        .select("id,class,weekday,period,subject,teacher,group_tag,subject_id,teacher_id")
-        .order("class", { ascending: true })
-        .order("weekday", { ascending: true })
-        .order("period", { ascending: true });
+      const { data: tt, error: e2 } = await withTimeout(
+        supabase
+          .from("timetable")
+          .select("id,class,weekday,period,subject,teacher,group_tag,subject_id,teacher_id")
+          .order("class", { ascending: true })
+          .order("weekday", { ascending: true })
+          .order("period", { ascending: true })
+      );
       if (e2) throw e2;
 
       schedule = (tt || []).map(x => {
@@ -940,7 +990,8 @@
       console.log(`[Supabase] loaded students=${students.length}, timetable=${schedule.length}, subjects=${subjectsById.size}, teachers=${teachersById.size}, links=${linkMap.size}`);
     } catch (err) {
       console.error("Load from Supabase failed:", err);
-      alert(t('errorLoadCoreData'));
+      const key=isTimeoutError(err)?'errorSupabaseTimeout':'errorLoadCoreData';
+      alert(t(key));
     }
   }
   document.addEventListener("DOMContentLoaded", loadCoreDataFromSupabase);
@@ -1736,12 +1787,16 @@ async function saveCurrentApplication(options={}){
     }
 
     const rowsForInsert=rows.map(r=>({ ...r }));
-    let { error } = await supabase.from('applications_flat').insert(rowsForInsert);
+    let { error } = await withTimeout(
+      supabase.from('applications_flat').insert(rowsForInsert)
+    );
     if(error){
       const msg=(error.message||'').toLowerCase();
       if(msg.includes('column') && msg.includes('department')){
         const stripped=rowsForInsert.map(({ department_cn, department_en, department_code, ...rest })=>rest);
-        const retry=await supabase.from('applications_flat').insert(stripped);
+        const retry=await withTimeout(
+          supabase.from('applications_flat').insert(stripped)
+        );
         if(retry.error) throw retry.error;
       }else{
         throw error;
@@ -1757,7 +1812,10 @@ async function saveCurrentApplication(options={}){
     return { text:t, saved:true };
   }catch(e){
     console.error('Save to Supabase failed:', e);
-    if(!silent) alert(t('saveFailed'));
+    if(!silent){
+      const key=isTimeoutError(e)?'errorSupabaseTimeout':'saveFailed';
+      alert(t(key));
+    }
     return null;
   }
 }
@@ -1808,12 +1866,24 @@ async function fetchFilteredRecordsFromCloud(){
   };
   let q = buildQuery(columnsFull);
 
-  let { data, error } = await q;
+  let data, error;
+  try{
+    ({ data, error } = await withTimeout(q));
+  }catch(err){
+    console.error('[records] Fetch failed:', err);
+    alert(t(isTimeoutError(err)?'errorSupabaseTimeout':'errorFetchRecords'));
+    return [];
+  }
   if (error){
     const msg=(error.message||'').toLowerCase();
     if(msg.includes('column') && msg.includes('department')){
-      q = buildQuery(columnsFallback);
-      ({ data, error } = await q);
+      try{
+        ({ data, error } = await withTimeout(buildQuery(columnsFallback)));
+      }catch(err){
+        console.error('[records] Fallback fetch failed:', err);
+        alert(t(isTimeoutError(err)?'errorSupabaseTimeout':'errorFetchRecords'));
+        return [];
+      }
     }
   }
   if (error){ console.error(error); alert(t('errorFetchRecords')); return []; }
@@ -1948,13 +2018,22 @@ btnDeleteSelected.onclick=async ()=>{
       alert(t('errorMissingDeleteKeys'));
       continue;
     }
-    const { error } = await supabase
-      .from('applications_flat')
-      .delete()
-      .match({ date, student_id: sid, client_ts: Number(ts) });
-    if(error){
-      console.error('[records] Delete failed:', error);
-      alert(t('errorDeletePartial'));
+    try{
+      const { error } = await withTimeout(
+        supabase
+          .from('applications_flat')
+          .delete()
+          .match({ date, student_id: sid, client_ts: Number(ts) })
+      );
+      if(error){
+        console.error('[records] Delete failed:', error);
+        alert(t('errorDeletePartial'));
+        refreshTable();
+        return;
+      }
+    }catch(err){
+      console.error('[records] Delete failed:', err);
+      alert(t(isTimeoutError(err)?'errorSupabaseTimeout':'errorDeletePartial'));
       refreshTable();
       return;
     }
@@ -1966,6 +2045,7 @@ btnDeleteSelected.onclick=async ()=>{
 
 /***** —— 监看（云端） —— */
 let monCloudCache = [];  // {date, period, student_id, class, name_cn, name_en, activity, department_*, client_ts}
+let lastMonitorError = null;
 async function ensureMonitorDefaults(){
   const hasDates = monDates.length>0;
   if(monitorDefaultInitialized && hasDates){
@@ -1983,10 +2063,12 @@ async function ensureMonitorDefaults(){
   }
 
   try {
-    const { data, error } = await supabase
-      .from('applications_flat')
-      .select('date', { distinct: true })
-      .order('date', { ascending: true });
+    const { data, error } = await withTimeout(
+      supabase
+        .from('applications_flat')
+        .select('date', { distinct: true })
+        .order('date', { ascending: true })
+    );
     if (error) throw error;
     const list = Array.from(new Set((data||[]).map(item => item.date).filter(Boolean))).sort();
     const todayStr = new Date().toISOString().slice(0,10);
@@ -2005,8 +2087,10 @@ async function ensureMonitorDefaults(){
       monitorDefaultActive = false;
       monitorDefaultInitialized = true;
     }
+    lastMonitorError = null;
   } catch (err) {
     console.error('[monitor] Failed to load default dates:', err);
+    lastMonitorError = err;
     monitorDefaultActive = false;
     monitorDefaultInitialized = false;
   }
@@ -2020,19 +2104,44 @@ async function loadMonitorRecordsFromCloud(){
     .from('applications_flat')
     .select(columnsFull)
     .in('date', monDates);
-  let { data, error } = await query;
+  let data, error;
+  try{
+    ({ data, error } = await withTimeout(query));
+  }catch(err){
+    console.error('[monitor] Load records failed:', err);
+    lastMonitorError = err;
+    alert(t(isTimeoutError(err)?'errorSupabaseTimeout':'errorMonitorFetch'));
+    monCloudCache = [];
+    return;
+  }
   if(error){
     const msg=(error.message||'').toLowerCase();
     if(msg.includes('column') && msg.includes('department')){
-      query = supabase
-        .from('applications_flat')
-        .select(columnsFallback)
-        .in('date', monDates);
-      ({ data, error } = await query);
+      try{
+        ({ data, error } = await withTimeout(
+          supabase
+            .from('applications_flat')
+            .select(columnsFallback)
+            .in('date', monDates)
+        ));
+      }catch(err){
+        console.error('[monitor] Fallback load records failed:', err);
+        lastMonitorError = err;
+        alert(t(isTimeoutError(err)?'errorSupabaseTimeout':'errorMonitorFetch'));
+        monCloudCache = [];
+        return;
+      }
     }
   }
-  if(error){ console.error(error); alert(t('errorMonitorFetch')); monCloudCache = []; return; }
+  if(error){
+    console.error(error);
+    lastMonitorError = error;
+    alert(t('errorMonitorFetch'));
+    monCloudCache = [];
+    return;
+  }
   monCloudCache = data || [];
+  lastMonitorError = null;
 }
 function getAllRecords(){ // 监看内部依赖的统一取数
   return monCloudCache.map(r=>({
@@ -2137,11 +2246,21 @@ async function buildMonitorView(){
   }
   monitorDefaultActive = monitorDefaultActive && monMode.value==='timetable';
   if(!monDates.length){
+    if(lastMonitorError){
+      const key=isTimeoutError(lastMonitorError)?'errorSupabaseTimeout':'errorMonitorFetch';
+      monResult.innerHTML=`<div class="muted">${escapeHtml(t(key))}</div>`;
+      return;
+    }
     monResult.innerHTML=`<div class="muted">${escapeHtml(t('errorMonitorNeedDate'))}</div>`;
     return;
   }
 
   await loadMonitorRecordsFromCloud();
+  if(lastMonitorError){
+    const key=isTimeoutError(lastMonitorError)?'errorSupabaseTimeout':'errorMonitorFetch';
+    monResult.innerHTML=`<div class="muted">${escapeHtml(t(key))}</div>`;
+    return;
+  }
 
   if(monMode.value==='timetable'){ buildMonitorTimetable(); return; }
 
@@ -2435,6 +2554,7 @@ const tabRecords=document.getElementById('tab-records');
 const pageApply=document.getElementById('page-apply');
 const pageRecords=document.getElementById('page-records');
 const pageMonitor=document.getElementById('page-monitor');
+const tabPages=[pageApply,pageRecords,pageMonitor];
 
 const TAB_COOKIE_NAME='leave_active_tab';
 const TAB_COOKIE_MAX_AGE=60*60*24*30; // 30 days
@@ -2514,14 +2634,14 @@ async function setActiveTab(which){
     t.setAttribute('aria-selected','false');
     t.tabIndex=-1;
   });
-  [pageApply,pageRecords,pageMonitor].forEach(p=>p.style.display='none');
-  if(which==='apply'){ tabApply.classList.add('active'); tabApply.setAttribute('aria-selected','true'); tabApply.tabIndex=0; pageApply.style.display='block'; }
-  if(which==='records'){ tabRecords.classList.add('active'); tabRecords.setAttribute('aria-selected','true'); tabRecords.tabIndex=0; pageRecords.style.display='block'; refreshTable(); }
-  if(which==='monitor'){
+  tabPages.forEach(p=>{ if(p){ p.classList.remove('is-active'); } });
+  if(which==='apply' && pageApply){ tabApply.classList.add('active'); tabApply.setAttribute('aria-selected','true'); tabApply.tabIndex=0; pageApply.classList.add('is-active'); }
+  if(which==='records' && pageRecords){ tabRecords.classList.add('active'); tabRecords.setAttribute('aria-selected','true'); tabRecords.tabIndex=0; pageRecords.classList.add('is-active'); refreshTable(); }
+  if(which==='monitor' && pageMonitor){
     tabMonitor.classList.add('active');
     tabMonitor.setAttribute('aria-selected','true');
     tabMonitor.tabIndex=0;
-    pageMonitor.style.display='block';
+    pageMonitor.classList.add('is-active');
     buildTeacherClassSelects();
     await ensureMonitorDefaults();
     if(monMode.value!=='timetable' && !monitorUserModified){
@@ -2556,7 +2676,7 @@ onLanguageChange(()=>{
   try{ buildTeacherClassSelects(); }catch(err){ console.warn('Failed to rebuild teacher/class lists after language change.',err); }
   try{ updateConflict(); }catch(err){ console.warn('Failed to update conflict notice after language change.',err); }
   document.querySelectorAll('#tblBody button[data-idx]').forEach(btn=>{ btn.textContent=t('deleteRecords'); });
-  if(pageMonitor && pageMonitor.style.display!=='none'){
+  if(pageMonitor && pageMonitor.classList.contains('is-active')){
     buildMonitorView();
   }
 });
@@ -2568,7 +2688,13 @@ if(languageSelect){
 }
 
 const initialTab=getTabCookie() || 'monitor';
-setActiveTab(initialTab);
+setActiveTab(initialTab)
+  .catch(err=>console.error('Failed to activate initial tab',err))
+  .finally(()=>{
+    if(document.body){
+      document.body.classList.add('js-tabs-ready');
+    }
+  });
 setLanguage(getCurrentLanguage(),{ persist:false });
 
 // Supabase 核心数据在模块顶部通过 DOMContentLoaded 注册加载


### PR DESCRIPTION
## Summary
- add a shared timeout helper for Supabase requests and a localized timeout alert message
- wrap save, records, and monitor data operations with timeout-aware handling so UI falls back cleanly when Supabase is slow
- surface monitor fetch failures inline to keep other tabs usable during network outages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7d70e26e08330bca0f91d7660f9a4